### PR TITLE
fix: hex_or_base64 digit recognition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,9 @@ pub trait GetInfo<T: ::serde::Serialize> {
 /// An even-length string with exclusively lowercase hex characters will be parsed as hex;
 /// failing that, it will be parsed as base64 and return an error accordingly.
 pub fn hex_or_base64(s: &str) -> Result<Vec<u8>, simplicity::base64::DecodeError> {
-	if s.len() % 2 == 0 && s.bytes().all(|b| b.is_ascii_hexdigit() && b.is_ascii_lowercase()) {
+	// Use explicit matching for lowercase hex (0-9, a-f) since is_ascii_lowercase()
+	// returns false for digits, causing valid hex strings to be parsed as base64
+	if s.len() % 2 == 0 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')) {
 		use simplicity::hex::FromHex as _;
 		Ok(Vec::from_hex(s).expect("charset checked above"))
 	} else {


### PR DESCRIPTION
## Summary

Fix a bug in the `hex_or_base64()` function where digits (0-9) were not recognized as valid lowercase hex characters.

## Problem

The original code used `is_ascii_lowercase()` to check for lowercase hex characters:

```rust
s.bytes().all(|b| b.is_ascii_hexdigit() && b.is_ascii_lowercase())
```

However, `is_ascii_lowercase()` returns `false` for digits `0-9`, causing valid lowercase hex strings like `"0a1b2c3d"` to be incorrectly parsed as base64 instead of hex.

## Solution

Use explicit pattern matching for valid lowercase hex characters (0-9, a-f):

```rust
s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
```

## Testing

This bug was discovered while using `hal-simplicity` for Simplicity transactions on Liquid Testnet. After the fix, hex strings containing digits are correctly parsed.