### PR TITLE
Release tracking PR: hal-simplicity 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
-# v0.1.0 - 2025-07-29
+# 0.2.0 - 2026-01-06
+
+- Remove second `simplicity` in all commands, so e.g. `hal-simplicity simplictiy simplicity info`
+  becomes `hal-simplicity simplicity info`.
+  [#13](https://github.com/BlockstreamResearch/hal-simplicity/pull/13)
+- Change the default NUMS key to match BIP-0341.
+  [#18](https://github.com/BlockstreamResearch/hal-simplicity/pull/18)
+- Refactor transaction construction to use PSET rather than raw transactions; add
+  the ability to compute sighashes and execute programs with trace output.
+  [#12](https://github.com/BlockstreamResearch/hal-simplicity/pull/12)
+  [#32](https://github.com/BlockstreamResearch/hal-simplicity/pull/32)
+  [#37](https://github.com/BlockstreamResearch/hal-simplicity/pull/37)
+- Extend `address inspect` to support Liquid Testnet.
+  [#27](https://github.com/BlockstreamResearch/hal-simplicity/pull/27)
+- Add basic state commitment support.
+  [#33](https://github.com/BlockstreamResearch/hal-simplicity/pull/33)
+- Begin refactoring process to allow use as a RPC server.
+  [#37](https://github.com/BlockstreamResearch/hal-simplicity/pull/37)
+  [#38](https://github.com/BlockstreamResearch/hal-simplicity/pull/38)
+
+# 0.1.0 - 2025-07-29
 
 - Initial release, including hal-elements functions and the `simplicity info` command

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "hal-simplicity"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "elements",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hal-simplicity"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Steven Roose <steven@stevenroose.org>", "Andrew Poelstra <apoelstra@blockstream.com>"]
 license = "CC0-1.0"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -82,7 +82,7 @@ fn assert_cmd(args: &[&str], expected_stdout: impl AsRef<str>, expected_stderr: 
 #[test]
 fn cli_help() {
 	let expected_help = "\
-hal-simplicity 0.1.0
+hal-simplicity 0.2.0
 hal-simplicity -- a Simplicity-enabled fork of hal
 
 USAGE:
@@ -126,7 +126,7 @@ For more information try --help
 #[test]
 fn cli_address() {
 	let expected_help = "\
-hal-simplicity-address 0.1.0
+hal-simplicity-address 0.2.0
 work with addresses
 
 USAGE:
@@ -149,7 +149,7 @@ SUBCOMMANDS:
 #[test]
 fn cli_address_create() {
 	let expected_help = "\
-hal-simplicity-address-create 0.1.0
+hal-simplicity-address-create 0.2.0
 create addresses
 
 USAGE:
@@ -587,7 +587,7 @@ For more information try --help
 #[test]
 fn cli_address_inspect() {
 	let expected_help = "\
-hal-simplicity-address-inspect 0.1.0
+hal-simplicity-address-inspect 0.2.0
 inspect addresses
 
 USAGE:
@@ -752,7 +752,7 @@ For more information try --help
 #[test]
 fn cli_block() {
 	let expected_help = "\
-hal-simplicity-block 0.1.0
+hal-simplicity-block 0.2.0
 manipulate blocks
 
 USAGE:
@@ -775,7 +775,7 @@ SUBCOMMANDS:
 #[test]
 fn cli_block_create() {
 	let expected_help = "\
-hal-simplicity-block-create 0.1.0
+hal-simplicity-block-create 0.2.0
 create a raw block from JSON
 
 USAGE:
@@ -931,7 +931,7 @@ ARGS:
 #[test]
 fn cli_block_decode() {
 	let expected_help = "\
-hal-simplicity-block-decode 0.1.0
+hal-simplicity-block-decode 0.2.0
 decode a raw block to JSON
 
 USAGE:
@@ -1008,7 +1008,7 @@ ARGS:
 #[test]
 fn cli_keypair() {
 	let expected_help = "\
-hal-simplicity-keypair 0.1.0
+hal-simplicity-keypair 0.2.0
 manipulate private and public keys
 
 USAGE:
@@ -1031,7 +1031,7 @@ SUBCOMMANDS:
 #[test]
 fn cli_keypair_generate() {
 	let expected_help = "\
-hal-simplicity-keypair-generate 0.1.0
+hal-simplicity-keypair-generate 0.2.0
 generate a random private/public keypair
 
 USAGE:
@@ -1067,7 +1067,7 @@ FLAGS:
 #[test]
 fn cli_simplicity() {
 	let expected_help = "\
-hal-simplicity-simplicity 0.1.0
+hal-simplicity-simplicity 0.2.0
 manipulate Simplicity programs
 
 USAGE:
@@ -1091,7 +1091,7 @@ SUBCOMMANDS:
 #[test]
 fn cli_simplicity_info() {
 	let expected_help = "\
-hal-simplicity-simplicity-info 0.1.0
+hal-simplicity-simplicity-info 0.2.0
 Parse a base64-encoded Simplicity program and decode it
 
 USAGE:
@@ -1137,7 +1137,7 @@ For more information try --help
 #[test]
 fn cli_tx() {
 	let expected_help = "\
-hal-simplicity-tx 0.1.0
+hal-simplicity-tx 0.2.0
 manipulate transactions
 
 USAGE:
@@ -1160,7 +1160,7 @@ SUBCOMMANDS:
 #[test]
 fn cli_tx_create() {
 	let expected_help = "\
-hal-simplicity-tx-create 0.1.0
+hal-simplicity-tx-create 0.2.0
 create a raw transaction from JSON
 
 USAGE:
@@ -1221,7 +1221,7 @@ ARGS:
 #[test]
 fn cli_tx_decode() {
 	let expected_help = "\
-hal-simplicity-tx-decode 0.1.0
+hal-simplicity-tx-decode 0.2.0
 decode a raw transaction to JSON
 
 USAGE:


### PR DESCRIPTION
Cut a release so that users don't need to use git dependencies to get PSET support, state management, etc.